### PR TITLE
Users/yuliang/title gen speedup

### DIFF
--- a/insta-ui/src/app/api/generate/route.ts
+++ b/insta-ui/src/app/api/generate/route.ts
@@ -64,7 +64,8 @@ export async function POST(req: Request) {
         const {refinedPrompt, topicName}  = refinedPromptCompletion.choices[0].message.content 
                                             ? extractRefinedPromptAndTitle(refinedPromptCompletion.choices[0].message.content, input.textInput)
                                             : {refinedPrompt: input.textInput, topicName: 'React UI Component Code generation.'};
-        console.log("Refined prompt:", refinedPrompt);
+        // console.log(revisionMessages);
+        // console.log(refinedPromptCompletion.choices[0])
 
         // Use the refined prompt to generate the component
         const messages = generateMessages(
@@ -72,7 +73,7 @@ export async function POST(req: Request) {
             input.imageInput,
             input.previousMessages,
         );
-        console.log("messages: ",messages)
+        //console.log("messages: ",messages)
 
         const completion = await openai.chat.completions.create({
             model: MODEL,

--- a/insta-ui/src/server/constants.ts
+++ b/insta-ui/src/server/constants.ts
@@ -1,1 +1,1 @@
-export const MODEL = "gpt-4o";
+export const MODEL = "gpt-4o-mini";

--- a/insta-ui/src/server/prompts.ts
+++ b/insta-ui/src/server/prompts.ts
@@ -4,8 +4,7 @@ export function generateMessages(
     textInput: string,
     imageInput?: string,
     previousCode?: string,
-    topicName?: boolean
-): { messages: Message[], topicMessages: Message[] } {
+): Message[] {
     const messages: Message[] = [
         {
             role: 'system',
@@ -55,35 +54,46 @@ export function generateMessages(
         content: userContent
     });
 
-    const topicMessages: Message[] = []
-    if (topicName) {
-        topicMessages.push({
-            role: 'system',
-            content: `You are a request title creator. You have to help the user summarize a request in no more than 6 words.`
-        });
-
-        const userContent: (TextContent | ImageContent)[] = [
-            { type: 'text', text: `Create a request title based on this description: ${textInput}` }
-        ];
-
-        if (imageInput) {
-            userContent.push({
-                type: 'image_url',
-                image_url: {
-                    url: imageInput
-                }
-            } as ImageContent);
-        }
-
-        topicMessages.push({
-            role: 'user',
-            content: userContent
-        });
-
-    }
-
-    return { messages, topicMessages };
+    return messages;
 }
+
+// export function generatePromptRevisionMessages(
+//     textInput: string, 
+//     imageInput?: string,
+//     previousCode?: string
+//   ): Message[] {
+//     return [
+//       {
+//         role: 'system',
+//         content: `You are a prompt engineer specializing in UI component generation.
+//         Help refine user requests into detailed, specific prompts that will result in better React components.
+//         Focus on:
+//         - Visual design details
+//         - Component functionality
+//         - User interaction patterns
+//         - Accessibility considerations
+//         - Responsive design requirements
+//         ${previousCode ? '- Integration with existing code' : ''}`
+//       },
+//       {
+//         role: 'user',
+//         content: [
+//           {
+//             type: 'text',
+//             text: previousCode
+//               ? `Refine this component request, considering both the new requirements and existing code:
+//                  New requirements: ${textInput}
+//                  Existing code: ${previousCode}`
+//               : `Refine this component request into a detailed prompt: ${textInput}`
+//           },
+//           ...(imageInput ? [{
+//             type: 'image_url',
+//             image_url: { url: imageInput }
+//           } as ImageContent] : [])
+//         ]
+//       }
+//     ];
+//   }
 
 export function generatePromptRevisionMessages(
     textInput: string, 
@@ -94,14 +104,19 @@ export function generatePromptRevisionMessages(
       {
         role: 'system',
         content: `You are a prompt engineer specializing in UI component generation.
-        Help refine user requests into detailed, specific prompts that will result in better React components.
-        Focus on:
-        - Visual design details
-        - Component functionality
-        - User interaction patterns
-        - Accessibility considerations
-        - Responsive design requirements
-        ${previousCode ? '- Integration with existing code' : ''}`
+          Help refine user requests into detailed, specific prompts that will result in better React components.
+          Focus on:
+          - Visual design details
+          - Component functionality
+          - User interaction patterns
+          - Accessibility considerations
+          - Responsive design requirements
+          ${previousCode ? '- Integration with existing code' : ''}
+          
+          Additionally, generate a concise title (6 words or less) summarizing the user's request.
+          Format the output as a JSON object containing two fields:
+          - "refined_prompt": The improved detailed prompt.
+          - "title": The concise title.`
       },
       {
         role: 'user',
@@ -109,10 +124,10 @@ export function generatePromptRevisionMessages(
           {
             type: 'text',
             text: previousCode
-              ? `Refine this component request, considering both the new requirements and existing code:
-                 New requirements: ${textInput}
-                 Existing code: ${previousCode}`
-              : `Refine this component request into a detailed prompt: ${textInput}`
+              ? `Refine this component request and include a title, considering both the new requirements and existing code:
+                New requirements: ${textInput}
+                Existing code: ${previousCode}`
+              : `Refine this component request and include a title: ${textInput}`
           },
           ...(imageInput ? [{
             type: 'image_url',
@@ -122,3 +137,4 @@ export function generatePromptRevisionMessages(
       }
     ];
   }
+  


### PR DESCRIPTION
### Summary
- Merge title generation into prompt revision, now it only takes about 10~15 second for LLM to respond.
- API interface stays the same.
- Change model choice back to 4o-mini

### Screenshot
![螢幕擷取畫面 2024-11-20 184758](https://github.com/user-attachments/assets/efb7a45a-52a6-4bb3-b4cd-350adf7cbf82)
result from 4o mini
![螢幕擷取畫面 2024-11-20 184833](https://github.com/user-attachments/assets/57316185-72cd-4c8d-b121-4d29b4d3c59f)
result from 4o

### Checklist
- [x] My code follows ESLint rules and passes all tests.
- [x] I have updated the documentation accordingly.